### PR TITLE
Trigger a fake facebook share or like event

### DIFF
--- a/firefox/AFBShare/data/afbshare.js
+++ b/firefox/AFBShare/data/afbshare.js
@@ -4,9 +4,9 @@
         return;    
     }
     var interval = window.setInterval( function () {
-        if (FB && FB.Event && FB.Event.fire ) {
+        if ( FB && FB.Event && FB.Event.fire ) {
             window.clearInterval(interval);
             FB.Event.fire('edge.create');
         }
-    });
+    }, 300);
 })();

--- a/firefox/AFBShare/data/afbshare.js
+++ b/firefox/AFBShare/data/afbshare.js
@@ -1,49 +1,12 @@
-var yurlFormat='https://www.youtube.com/watch?v=';
-var cases={
-	'html5':function(){
-		var yvideo=document.querySelector('[data-videoid]');
-		return yvideo? yvideo.getAttribute('data-videoid'):null;
-	}
-	,'embedded':function(){
-		var format='https://www.youtube.com/embed';
-		var regex=/https\:\/\/www\.youtube\.com\/embed\/(.*)\?.*/gi;
-
-		var yvideo=document.querySelector('iframe[src^="'+format+'"]');
-
-		return yvideo?yvideo.src.replace(regex,'$1'):null;
-	}
-	,'full':function(){
-		var format='https://www.youtube.com/watch?v=';
-		var regex=/https\:\/\/www\.youtube\.com\/watch?.*v\=(.*)\&.*/gi;
-
-		var yvideo=document.querySelector('iframe[src^="'+format+'"]');
-
-		return yvideo?yvideo.src.replace(regex,'$1'):null;
-	}
-	, 'shared':function(){
-		var format='http://youtu.be/';
-		var regex=/https\:\/\/youtu\.be\/(.*)/gi;
-
-		var yvideo=document.querySelector('iframe[src^="'+format+'"]');
-
-		return yvideo?yvideo.src.replace(regex,'$1'):null;
-	}
-	,'emebed-object':function(){
-		var format='http://www.youtube.com/v/';
-		var regex=/https\:\/\/www\.youtube\.com\/v\/(.*)/gi;
-
-		var yvideo=document.querySelector('[src^="'+format+'"]');
-
-		return yvideo?yvideo.src.replace(regex,'$1'):null;
-	}
-};
-
-
-	var yvideoid;
-	for(var i in cases){
-		yvideoid=cases[i]();
-
-		if(yvideoid)
-			break;
-	}
-	yvideoid? window.open(yurlFormat+yvideoid):'';
+(function () {
+    if (!FB) {
+        //no facebook script detected
+        return;    
+    }
+    var interval = window.setInterval( function () {
+        if (FB && FB.Event && FB.Event.fire ) {
+            window.clearInterval(interval);
+            FB.Event.fire('edge.create');
+        }
+    });
+})();


### PR DESCRIPTION
I found an alternative way to hide the facebook share pop up.

You could trigger a share event by simple using a FB.Event.fire method. 
This is a draft implementation and I haven't much time to test it. 
You probably don't want to merge on master (you could create another branch so I could PR it there).
